### PR TITLE
Adds geocodio npm module

### DIFF
--- a/modules/modules.js
+++ b/modules/modules.js
@@ -2,6 +2,7 @@ module['exports'] = {
   "cheerio": "^0.17.0",
   "colors": "^1.0.3",
   "cron": "^1.0.5",
+  "geocodio": "^0.0.1",
   "github": "^0.2.2",
   "gm": "^1.16.0",
   "hyperquest": "^1.0.1",


### PR DESCRIPTION
The [Geocodio module](https://www.npmjs.org/package/geocodio) is an api wrapper for the [Geocodio geocoding service](http://geocod.io/)

[Example usage](https://gist.github.com/desmondmorris/aa4628375ba9b38adffb#file-hookio-geocoder-js-L20)
