### PR TITLE
Redirect to the new hook name after save

### DIFF
--- a/view/admin.js
+++ b/view/admin.js
@@ -162,7 +162,7 @@ module['exports'] = function view (opts, callback) {
         });
 
         cache.set(key, result, function(){
-          return res.redirect('/admin?owner=' + req.hook.owner + "&name=" + req.hook.name + "&status=saved");
+          return res.redirect('/admin?owner=' + req.hook.owner + "&name=" + data.name + "&status=saved");
         });
       });
 


### PR DESCRIPTION
Changing the name and hitting save caused a 404 not found error. The new name should be used in the redirect.