### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "merge-params": "https://github.com/bigcompany/merge-params/tarball/master",
     "merge-stream": "^0.1.8",
     "microcule": "https://github.com/stackvana/microcule/tarball/master",
-    "microservice-examples": "https://github.com/stackvana/microcule-examples/tarball/master",
+    "microcule-examples": "https://github.com/stackvana/microcule-examples/tarball/master",
     "mime": "^1.2.11",
     "minimist": "^1.1.1",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.11.6
BuildVersion:	15G31

$ docker -v
Docker version 17.06.0-ce, build 02c1d87

root@8f49bc7a0cbc:/src# npm install
npm WARN package.json hook.io@1.0.0 No repository field.
npm WARN package.json hook.io@1.0.0 license should be a valid SPDX license expression
npm WARN deprecated node-uuid@1.4.8: Use uuid module instead
npm ERR! Linux 4.9.31-moby
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.7
npm ERR! npm  v2.14.1

npm ERR! Invalid Package: expected microservice-examples but found microcule-examples
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /src/npm-debug.log